### PR TITLE
Split Web and API routing configuration

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -1,3 +1,8 @@
 index:
   path: /
   controller: App\Controller\HomepageController::index
+
+# Vsetky API routy (s prefixom /api) som si vyhradil pre prehladnost do zvlast suboru routes_api.yml
+api:
+  prefix: /api
+  resource: 'routes_api.yml'

--- a/config/routes_api.yml
+++ b/config/routes_api.yml
@@ -1,0 +1,3 @@
+skillmatrix:
+  path: /skillmatrix
+  controller: App\Controller\Api\SkillmatrixController::get

--- a/src/Controller/Api/SkillmatrixController.php
+++ b/src/Controller/Api/SkillmatrixController.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace App\Controller\Api;
+
+use App\Service\SkillmatrixService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class SkillmatrixController
+{
+    /**
+     * @var \App\Service\SkillmatrixService
+     */
+    private $skillmatrixService;
+
+    public function __construct(SkillmatrixService $skillmatrixService)
+    {
+        $this->skillmatrixService = $skillmatrixService;
+    }
+
+    public function get(): JsonResponse
+    {
+        $skillmatrix = $this->skillmatrixService->get();
+
+        return new JsonResponse($skillmatrix);
+    }
+}


### PR DESCRIPTION
Split API routing (prefix /api) configuration into stand-alone file _routes_api.yml_.
Web routes are in default routin config file _routes.yaml_.
Add first API controller SkillmatrixController.